### PR TITLE
Ensure that the chef-vault-testfixtures gem is installed in the provider

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,13 +25,63 @@ provisioner:
 <% end %>
 
 platforms:
+  - name: ubuntu-12.04-11.10.4
+    driver:
+      require_chef_omnibus: 11.10.4
+      box: opscode-ubuntu-12.04
+      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
+  - name: ubuntu-12.04-11.12.8
+    driver:
+      require_chef_omnibus: 11.12.8
+      box: opscode-ubuntu-12.04
+      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
+  - name: ubuntu-12.04-11.14.6
+    driver:
+      require_chef_omnibus: 11.14.6
+      box: opscode-ubuntu-12.04
+      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
+  - name: ubuntu-12.04-11.16.4
+    driver:
+      require_chef_omnibus: 11.16.4
+      box: opscode-ubuntu-12.04
+      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
+  - name: ubuntu-12.04-11.18.6
+    driver:
+      require_chef_omnibus: 11.18.6
+      box: opscode-ubuntu-12.04
+      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
   - name: ubuntu-12.04
   - name: ubuntu-14.04
+  - name: centos-6.6-11.10.4
+    driver:
+      require_chef_omnibus: 11.10.4
+      box: opscode-ubuntu-12.04
+      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6_chef-provisionerless.box
+  - name: centos-6.6-11.12.8
+    driver:
+      require_chef_omnibus: 11.12.8
+      box: opscode-ubuntu-12.04
+      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6_chef-provisionerless.box
+  - name: centos-6.6-11.14.6
+    driver:
+      require_chef_omnibus: 11.14.6
+      box: opscode-ubuntu-12.04
+      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6_chef-provisionerless.box
+  - name: centos-6.6-11.16.4
+    driver:
+      require_chef_omnibus: 11.16.4
+      box: opscode-ubuntu-12.04
+      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6_chef-provisionerless.box
+  - name: centos-6.6-11.18.6
+    driver:
+      require_chef_omnibus: 11.18.6
+      box: opscode-ubuntu-12.04
+      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6_chef-provisionerless.box
   - name: centos-6.6
   - name: centos-7.0
 
 suites:
-  - name: plugins_chef_gem
+  - name: chef_gem
     run_list:
       - recipe[testsetup::plugins_chef_gem]
       - recipe[chef_vault_testfixtures::default]
@@ -46,24 +96,7 @@ suites:
           chef-vault-testfixture-plugin-bar:
             source: /tmp/kitchen/chef-vault-testfixture-plugin-bar-0.1.0.gem
             version: 0.1.0
-  - name: plugins_chef_gem_chef11
-    driver_config:
-      require_chef_omnibus: 11.18.0
-    run_list:
-      - recipe[testsetup::plugins_chef_gem]
-      - recipe[chef_vault_testfixtures::default]
-      - recipe[testsetup::render_secret_foo]
-      - recipe[testsetup::render_secret_bar]
-    attributes:
-      chef_vault_testfixtures:
-        install_gems:
-          chef-vault-testfixture-plugin-foo:
-            source: /tmp/kitchen/chef-vault-testfixture-plugin-foo-0.1.0.gem
-            version: 0.1.0
-          chef-vault-testfixture-plugin-bar:
-            source: /tmp/kitchen/chef-vault-testfixture-plugin-bar-0.1.0.gem
-            version: 0.1.0
-  - name: plugins_git
+  - name: git
     run_list:
       - recipe[testsetup::plugins_git]
       - recipe[chef_vault_testfixtures::default]
@@ -79,7 +112,7 @@ suites:
             install_type: git
             repository: file:////tmp/kitchen/chef-vault-testfixture-plugin-bar
             revision: my_fix_to_bar
-  - name: plugins_whitelist
+  - name: whitelist
     run_list:
       - recipe[testsetup::plugins_chef_gem]
       - recipe[chef_vault_testfixtures::default]
@@ -94,7 +127,7 @@ suites:
           chef-vault-testfixture-plugin-bar:
             source: /tmp/kitchen/chef-vault-testfixture-plugin-bar-0.1.0.gem
             version: 0.1.0
-  - name: plugins_blacklist
+  - name: blacklist
     run_list:
       - recipe[testsetup::plugins_chef_gem]
       - recipe[chef_vault_testfixtures::default]

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -4,4 +4,4 @@ DEPENDENCIES
     metadata: true
 
 GRAPH
-  chef_vault_testfixtures (0.1.0)
+  chef_vault_testfixtures (0.1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# Revision History for chef_vault_testfixtures
+# Revision History for chef_vault_testfixtures cookbook 
+
+## 0.1.1
+
+* ensure that the chef-vault-testfixtures gem is installed in the provider code before it is required
+* use --conservative when installing chef-vault-testfixtures gem so as not to kick off an upgrade of chef
+* expand test kitchen platforms to include chef-clients back to 11.10.x
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -35,20 +35,27 @@ assume you are using Berkshelf for cookbook dependency management.
 In your `Berksfile`, add a snippet that pulls this cookbook into a test group:
 
     group :test do
-      cookbook 'chef_vault_testfixtures', '~> 0.1'
+      cookbook 'chef_vault_testfixtures', '~> 0.2'
     end
 
-In your `.kitchen.yml`, add this cookbook to the run list for each suite:
+In your `.kitchen.yml`, add this cookbook to the run list for each suite
+and which fixture data plugins to install:
 
     suites:
       - name: default
         run_list:
           - recipe[chef_vault_testfixtures]
           - recipe[your_normal_cookbook_here]
+        attributes:
+          chef_vault_testfixtures:
+            install_gems:
+              chef-vault-testfixtures-myapp:
+                install_type: git
+                repository: https://github.com/myusername/chef-vault-testfixtures-myapp.git
 
 When Test Kitchen converges your cookbook, it will create a new
 client identity (including a public/private keypair).  This cookbook
-will then create a vaultitem for each plugin that
+will then create a vaultitem for each plugin that it finds.
 
 ## Recipes
 
@@ -71,6 +78,7 @@ Attribute | Description | Type   | Default
 plugins | List of plugins to load | Array | [] (means load all)
 disregard_plugin | List of plugins to not load | Array | []
 install_gems | Hash of plugin gems to install | Hash | see below
+gem_version | constrain chef-vault-testfixtures gem version | String | ~> 0.2
 
 ## Specifying Plugins
 
@@ -86,15 +94,18 @@ cookbook in `.kitchen.yml`:
         attributes:
           chef_vault_testfixtures:
             install_gems:
-              my_vault_plugin_db: {}
-              my_vault_plugin_rmq:
+              chef-vault-testfixtures-db: {}
+              chef-vault-testfixtures-rmq:
                 install_type: git
-                repository: https://github.com/myusername/my_chef_vault_rmq_plugin.git
+                repository: https://github.com/myusername/chef-vault-testfixtures-rmq.git
                 revision: my_fix_branch
 
 The install_gems attribute is a hash.  The keys are the names of the
 vault plugins to install and the values tell the cookbook how to install
 the plugin.
+
+Note that the name of the vault plugin in .kitchen.yml must match the name
+of the gem (on Rubygems or in the gemspec in a git repo).
 
 The value is a Hash that can contain the following keys:
 
@@ -119,7 +130,7 @@ do things like use an internal Geminabox server:
     attributes:
       chef_vault_testfixtures:
         install_gems:
-          db:
+          chef-vault-testfixtures-db:
             options: --clear-sources --no-rdoc --no-ri --source https://gems.mycompany.int
 
 ### git installation method
@@ -200,7 +211,7 @@ to use.
     chef_vault_testfixture_plugin 'my_vault_fixture_plugin' do
       action :nothing
       install_type 'git'
-      repository 'https://git.mycompany.int/scm/gems/my_vault_testfixtures.git'
+      repository 'https://git.mycompany.int/scm/gems/my_vault_fixture_plugin.git'
       revision 'v1.2.3'
     end
     c.run_action(:install)
@@ -307,12 +318,27 @@ to start over and create a new node, client, and keypair.
 
 ## Supported Platforms
 
-This cookbook is tested under Test Kitchen for the following platforms:
+This cookbook is tested under Test Kitchen for the following platforms
+and chef-client combinations:
 
 * ubuntu-12.04
+  * chef-client 11.10.4
+  * chef-client 11.12.8
+  * chef-client 11.14.6
+  * chef-client 11.16.4
+  * chef-client 11.18.6
+  * chef-client latest
 * ubuntu-14.04
+  * chef-client latest
 * centos-6.6
+  * chef-client 11.10.4
+  * chef-client 11.12.8
+  * chef-client 11.14.6
+  * chef-client 11.16.4
+  * chef-client 11.18.6
+  * chef-client latest
 * centos-7.0
+  * chef-client latest
 
 ## Author
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,10 @@ default['chef_vault_testfixtures']['disregard_plugin'] = []
 # overrride this to install plugin gems before creating the vaults
 default['chef_vault_testfixtures']['install_gems'] = {}
 
+# override this to change what version of the chef-vault-testfixtures
+# gem is installed by the cookbook
+default['chef_vault_testfixtures']['gem_version'] = '~> 0.2'
+
 # example: install using chef_gem from Rubygems or an internal Geminabox
 # default['chef_vault_testfixtures']['install_gems'].tap |o|
 #   o['my_vault_testfixtures'].tap |gem|

--- a/libraries/provider_chef_vault_testfixture_plugin.rb
+++ b/libraries/provider_chef_vault_testfixture_plugin.rb
@@ -73,9 +73,7 @@ class Chef
       # @param nr [Chef::Resource] the resource
       # @return [String] the path the git repo was cloned to
       def clone_git_repo(nr)
-        checkout_path = ::File.join(
-          Chef::Config[:file_cache_path], nr.gem_name
-        )
+        checkout_path = ::File.join(Chef::Config[:file_cache_path], nr.gem_name)
         at_compile_time do
           git checkout_path do
             action :checkout

--- a/libraries/provider_chef_vault_testfixture_vault.rb
+++ b/libraries/provider_chef_vault_testfixture_vault.rb
@@ -15,6 +15,7 @@ class Chef
       # dispatches to install_chef_gem or install_git based on
       # the install_type attribute of the resource
       action :create do
+        include_recipe 'chef_vault_testfixtures::_install_chefvault_gems'
         require 'chef-vault/test_fixtures'
 
         # make sure we have a plugin by that name

--- a/libraries/provider_chef_vault_testfixtures.rb
+++ b/libraries/provider_chef_vault_testfixtures.rb
@@ -4,6 +4,7 @@ class Chef
   class Provider
     # provides the chef_vault_testfixtures_plugin resource
     class ChefVaultTestfixtures < Chef::Provider::LWRPBase
+      include Chef::DSL::IncludeRecipe
       include ChefVaultTestFixtures::AtCompileTime
 
       use_inline_resources if defined?(use_inline_resources)
@@ -15,6 +16,7 @@ class Chef
       # dispatches to install_chef_gem or install_git based on
       # the install_type attribute of the resource
       action :create do
+        include_recipe 'chef_vault_testfixtures::_install_chefvault_gems'
         require 'chef-vault/test_fixtures'
 
         # set the plugin white/black lists from our attributes

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ maintainer       'Nordstrom, Inc.'
 maintainer_email 'james.i.fitzgibbon@nordstrom.com'
 license          'apache2'
 description      'Sets up testing fixtures for cookbooks using chef-vault'
-version          '0.1.0'
+version          '0.1.1'
 
 supports         'ubuntu', '= 12.04'
 supports         'ubuntu', '= 14.04'

--- a/recipes/_install_chefvault_gems.rb
+++ b/recipes/_install_chefvault_gems.rb
@@ -9,6 +9,10 @@
 # time.
 at_compile_time do
   chef_gem 'chef-vault-testfixtures' do
-    version '~> 0.1'
+    version node['chef_vault_testfixtures']['gem_version']
+    # don't try to upgrade chef (because that pulls in Chef 12,
+    # which pulls in Ohai 8, which doesn't work on Ruby 1.9.x,
+    # which is what chef-client 11 packages)
+    options '--conservative'
   end
 end


### PR DESCRIPTION
Ensure that the chef-vault-testfixtures gem is installed in the provider code before it is required

Use --conservative when installing chef-vault-testfixtures gem so as not to kick off an upgrade of chef
Expand test kitchen platforms to include chef-clients back to 11.10.x
Version bump to 0.11
Closes #1